### PR TITLE
Add tests for Pet Service

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     "homepage": "http://vspedr.github.io/developets",
     "devDependencies": {
         "concurrently": "^5.0.0",
-        "json-server": "^0.15.1"
+        "json-server": "^0.15.1",
+        "moxios": "^0.4.0"
     },
     "husky": {
         "hooks": {

--- a/src/services/pets.test.js
+++ b/src/services/pets.test.js
@@ -1,0 +1,45 @@
+import moxios from "moxios";
+import fetchPets from "./pets";
+
+describe("Pets Service", () => {
+
+  beforeEach(() => {
+    moxios.install();
+  });
+
+  afterEach(() => {
+    moxios.uninstall();
+  });
+
+  const petsResponse = [
+    {
+      id: "aaaaaa-bbbb-ccccc-ddddd-eeeeeeeee",
+      name: "KitKat",
+      owner: "Hershey",
+      type: "cat",
+      description: "A pretty kitty",
+      img: null
+    },
+    {
+      id: "11111-2222-3333-44444-555555555",
+      name: "Reeses",
+      owner: "H. B. Reese",
+      type: "dog",
+      description: "A very good boy",
+      img: null
+    }
+  ];
+  const config = {};
+
+  it("fetchPets returns data from the pets endpoint ", async () => {
+    const petsUrl = `${process.env.REACT_APP_API_URL}/pets`;
+    moxios.stubRequest(petsUrl, {
+      status: 200,
+      response: petsResponse
+    });
+
+    const pets = await fetchPets(config);
+
+    expect(pets.data).toBe(petsResponse);
+  });
+});


### PR DESCRIPTION
In an ongoing effort for 100% code coverage (from https://github.com/vspedr/developets/issues/19). 

This adds a fairly simple test to get full coverage of the `src/services/pets.js` file by ensuring it fetches from a specific endpoint and returns the data retrieved.